### PR TITLE
Grammar fix + term fix for "streaming"

### DIFF
--- a/includes/media-services-learning-paths-include.md
+++ b/includes/media-services-learning-paths-include.md
@@ -1,6 +1,6 @@
 Vous pouvez afficher les parcours d’apprentissage d’AMS ici :
 
-- [Workflow en flux continu AMS](https://azure.microsoft.com/documentation/learning-paths/media-services-streaming-live/)
-- [Workflow de streaming à la demande AMS](https://azure.microsoft.com/documentation/learning-paths/media-services-streaming-on-demand/)
+- [Workflow du streaming en continu AMS](https://azure.microsoft.com/documentation/learning-paths/media-services-streaming-live/)
+- [Workflow du streaming à la demande AMS](https://azure.microsoft.com/documentation/learning-paths/media-services-streaming-on-demand/)
 
 <!---HONumber=AcomDC_0128_2016-->


### PR DESCRIPTION
- Minor Grammar fix ("de" --> "du")
- Made the translation of "on demand streaming" consistent with the translation of "live streaming" 

There is a broader inconsistency around how "On demand streaming" and "Live Streaming" are translated into French in TermStudio:
Options for **live** streaming include: "vidéo en flux continu", "streaming en direct", etc 

Additionally, "streaming" is translated in TermStudio as "diffusion en continu" (meaning "live broadcast")

I'll open an issue for that broader terminology issue